### PR TITLE
fix: unable to find emoji definitions when using cocoapods

### DIFF
--- a/MCEmojiPicker.podspec
+++ b/MCEmojiPicker.podspec
@@ -8,7 +8,12 @@ Pod::Spec.new do |s|
   
   s.source = { :git => 'https://github.com/izyumkin/MCEmojiPicker.git', :tag => s.version.to_s }
   s.source_files = 'Sources/MCEmojiPicker/**/*.swift'
-  s.resource_bundle = { "MCEmojiPicker" => ["Sources/MCEmojiPicker/**/*.lproj/*.strings"] }
+  s.resource_bundles = { 
+    "MCEmojiPicker" => [
+      "Sources/MCEmojiPicker/Resources/EmojiDefinitions/*.json",
+      "Sources/MCEmojiPicker/**/*.lproj/*.strings"
+    ] 
+  }
   s.swift_version = '4.2'
   s.platform = :ios, '11.1'
 end


### PR DESCRIPTION
Hey, 

After recent changes from version 1.2.5 the podspec wasn't updated to contain EmojiDefintions, I was getting following error:

![CleanShot 2025-06-25 at 20 55 32@2x](https://github.com/user-attachments/assets/442e3f7a-7f8a-4b56-a7cd-186fd1ac6e8d)

Also, I'm not sure if the localization strings are still needed because they are not referenced by Package.swift