### PR TITLE
Add visionOS support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .swiftpm/
 .DS_Store
+xcuserdata/

--- a/Example App/MCEmojiPicker.xcodeproj/project.pbxproj
+++ b/Example App/MCEmojiPicker.xcodeproj/project.pbxproj
@@ -474,9 +474,12 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "izyumkin.iOS-Example-App";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator xros xrsimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = "1,2,7";
 			};
 			name = Debug;
 		};
@@ -504,9 +507,12 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "izyumkin.iOS-Example-App";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator xros xrsimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = "1,2,7";
 			};
 			name = Release;
 		};

--- a/Example App/MCEmojiPicker.xcodeproj/project.pbxproj
+++ b/Example App/MCEmojiPicker.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		C44B58C729867F66006478D5 /* MCEmojiPicker in Frameworks */ = {isa = PBXBuildFile; productRef = C44B58C629867F66006478D5 /* MCEmojiPicker */; };
 		C49629B329873E2F0070BE66 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = C49629B529873E2F0070BE66 /* Localizable.strings */; };
 		C49629BC298744EE0070BE66 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C49629BA298744EE0070BE66 /* LaunchScreen.storyboard */; };
+		DCD11A012E6D082D00207654 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCD11A002E6D082D00207654 /* SceneDelegate.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -63,6 +64,7 @@
 		C49629E0298747AF0070BE66 /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/Localizable.strings; sourceTree = "<group>"; };
 		C49629E1298747B30070BE66 /* uk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = uk; path = uk.lproj/Localizable.strings; sourceTree = "<group>"; };
 		C49629E2298747B80070BE66 /* vi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = vi; path = vi.lproj/Localizable.strings; sourceTree = "<group>"; };
+		DCD11A002E6D082D00207654 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -143,6 +145,7 @@
 			isa = PBXGroup;
 			children = (
 				C44B58B429867F5E006478D5 /* AppDelegate.swift */,
+				DCD11A002E6D082D00207654 /* SceneDelegate.swift */,
 			);
 			path = App;
 			sourceTree = "<group>";
@@ -270,6 +273,7 @@
 			files = (
 				C44B58B929867F5E006478D5 /* ViewController.swift in Sources */,
 				C44B58B529867F5E006478D5 /* AppDelegate.swift in Sources */,
+				DCD11A012E6D082D00207654 /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Example App/MCEmojiPicker.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Example App/MCEmojiPicker.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Example App/iOS Example App/App/AppDelegate.swift
+++ b/Example App/iOS Example App/App/AppDelegate.swift
@@ -24,19 +24,16 @@ import UIKit
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
-    
-    var window: UIWindow?
-    
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        #if os(visionOS)
-        let windowScene = application.connectedScenes.first { $0 is UIWindowScene } as! UIWindowScene
-        window = UIWindow(windowScene: windowScene)
-        #else
-        window = UIWindow(frame: UIScreen.main.bounds)
-        #endif
-        window?.rootViewController = ViewController()
-        window?.makeKeyAndVisible()
         return true
+    }
+
+    func application(
+        _ application: UIApplication,
+        configurationForConnecting connectingSceneSession: UISceneSession,
+        options: UIScene.ConnectionOptions
+    ) -> UISceneConfiguration {
+        UISceneConfiguration(name: "Default Configuration", sessionRole: .windowApplication)
     }
 }
 

--- a/Example App/iOS Example App/App/AppDelegate.swift
+++ b/Example App/iOS Example App/App/AppDelegate.swift
@@ -28,7 +28,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        #if os(visionOS)
+        let windowScene = application.connectedScenes.first { $0 is UIWindowScene } as! UIWindowScene
+        window = UIWindow(windowScene: windowScene)
+        #else
         window = UIWindow(frame: UIScreen.main.bounds)
+        #endif
         window?.rootViewController = ViewController()
         window?.makeKeyAndVisible()
         return true

--- a/Example App/iOS Example App/App/SceneDelegate.swift
+++ b/Example App/iOS Example App/App/SceneDelegate.swift
@@ -1,0 +1,26 @@
+//
+//  SceneDelegate.swift
+//  iOS Example App
+//
+//  Created by Harlan Haskins on 9/6/25.
+//
+
+import Foundation
+import UIKit
+
+@objc(SceneDelegate)
+final class SceneDelegate: NSObject, UIWindowSceneDelegate {
+    var window: UIWindow?
+
+    func scene(
+        _ scene: UIScene,
+        willConnectTo session: UISceneSession,
+        options connectionOptions: UIScene.ConnectionOptions
+    ) {
+        guard let windowScene = scene as? UIWindowScene else { return }
+        let window = UIWindow(windowScene: windowScene)
+        window.rootViewController = ViewController()
+        window.makeKeyAndVisible()
+        self.window = window
+    }
+}

--- a/Example App/iOS Example App/Resources/Info.plist
+++ b/Example App/iOS Example App/Resources/Info.plist
@@ -1,5 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<true/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>SceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+</dict>
 </plist>

--- a/Sources/MCEmojiPicker/Common/Extensions/Double+Extension.swift
+++ b/Sources/MCEmojiPicker/Common/Extensions/Double+Extension.swift
@@ -35,14 +35,18 @@ extension Double {
     /// Used to increase various sizes (fonts, heights and widths).
     /// - Parameter isOnlyToIncrease: Responsible for whether the value will decrease if the screen size is smaller than the default.
     func fit(isOnlyToIncrease: Bool = true) -> Double {
-        let defaultScreenSize = CGSize(width: 375, height: 812)
-        let currentScreenSize = UIScreen.main.bounds.size
+        #if os(iOS)
         // Check the type of the current device, if it is not a phone, return the original value.
         guard UIDevice.current.userInterfaceIdiom == .phone else { return self }
+        let defaultScreenSize = CGSize(width: 375, height: 812)
+        let currentScreenSize = UIScreen.main.bounds.size
         var scale = 1.0
         if isOnlyToIncrease && currentScreenSize.height > defaultScreenSize.height || !isOnlyToIncrease {
             scale = currentScreenSize.height / defaultScreenSize.height
         }
         return self * scale
+        #else
+        return self
+        #endif
     }
 }

--- a/Sources/MCEmojiPicker/Common/Extensions/UIColor+Extension.swift
+++ b/Sources/MCEmojiPicker/Common/Extensions/UIColor+Extension.swift
@@ -23,20 +23,36 @@
 import UIKit
 
 extension UIColor {
+    /// Standard secondary text color for headers and unselected buttons
+    static let secondaryText: UIColor = if #available(iOS 13.0, *) {
+        .secondaryLabel
+    } else {
+        .systemGray
+    }
+
     /// Background color for `MCEmojiPickerView`.
     ///
     /// This is a standard color from UIKit - `.systemGroupedBackground`.
+    #if os(visionOS)
+    static let popoverBackgroundColor = UIColor.clear
+    #else
     static let popoverBackgroundColor = UIColor(
         light:  UIColor(red: 0.95, green: 0.95, blue: 0.97, alpha: 1.0),
         dark: UIColor(red: 0.11, green: 0.11, blue: 0.12, alpha: 1.0)
     )
+    #endif
+
     /// Background color for `MCEmojiSkinTonePickerBackgroundView` and `MCEmojiPreviewView`.
     ///
     /// The colors were taken from similar iOS elements.
+    #if os(visionOS)
+    static let previewAndSkinToneBackgroundViewColor = UIColor.clear
+    #else
     static let previewAndSkinToneBackgroundViewColor = UIColor(
         light: UIColor(red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0),
         dark: UIColor(red: 0.45, green: 0.45, blue: 0.46, alpha: 1.0)
     )
+    #endif
 }
 
 extension UIColor {

--- a/Sources/MCEmojiPicker/Common/Extensions/View+Extension.swift
+++ b/Sources/MCEmojiPicker/Common/Extensions/View+Extension.swift
@@ -35,6 +35,7 @@ extension View {
     ///     - isDismissAfterChoosing: A boolean value that determines whether the screen will be hidden after the emoji is selected.
     ///     - selectedEmojiCategoryTintColor: Color for the selected emoji category.
     ///     - feedBackGeneratorStyle: Feedback generator style. To turn off, set `nil` to this parameter.
+    #if os(iOS)
     @ViewBuilder public func emojiPicker(
         isPresented: Binding<Bool>,
         selectedEmoji: Binding<String>,
@@ -56,7 +57,31 @@ extension View {
                 selectedEmojiCategoryTintColor: selectedEmojiCategoryTintColor,
                 feedBackGeneratorStyle: feedBackGeneratorStyle
             )
-                .allowsHitTesting(false)
+            .allowsHitTesting(false)
         )
     }
+    #else
+    @ViewBuilder public func emojiPicker(
+        isPresented: Binding<Bool>,
+        selectedEmoji: Binding<String>,
+        arrowDirection: MCPickerArrowDirection? = nil,
+        customHeight: CGFloat? = nil,
+        horizontalInset: CGFloat? = nil,
+        isDismissAfterChoosing: Bool? = nil,
+        selectedEmojiCategoryTintColor: UIColor? = nil
+    ) -> some View {
+        self.overlay(
+            MCEmojiPickerRepresentableController(
+                isPresented: isPresented,
+                selectedEmoji: selectedEmoji,
+                arrowDirection: arrowDirection,
+                customHeight: customHeight,
+                horizontalInset: horizontalInset,
+                isDismissAfterChoosing: isDismissAfterChoosing,
+                selectedEmojiCategoryTintColor: selectedEmojiCategoryTintColor
+            )
+            .allowsHitTesting(false)
+        )
+    }
+    #endif
 }

--- a/Sources/MCEmojiPicker/View/MCEmojiPickerRepresentableController.swift
+++ b/Sources/MCEmojiPicker/View/MCEmojiPickerRepresentableController.swift
@@ -63,14 +63,17 @@ public struct MCEmojiPickerRepresentableController: UIViewControllerRepresentabl
     ///
     /// The default value of this property is `.systemBlue`.
     public var selectedEmojiCategoryTintColor: UIColor?
-    
+
+    #if os(iOS)
     /// Feedback generator style. To turn off, set `nil` to this parameter.
     ///
     /// The default value of this property is `.light`.
     public var feedBackGeneratorStyle: UIImpactFeedbackGenerator.FeedbackStyle?
-    
+    #endif
+
     // MARK: - Initializers
-    
+
+    #if os(iOS)
     public init(
         isPresented: Binding<Bool>,
         selectedEmoji: Binding<String>,
@@ -90,7 +93,26 @@ public struct MCEmojiPickerRepresentableController: UIViewControllerRepresentabl
         self.selectedEmojiCategoryTintColor = selectedEmojiCategoryTintColor
         self.feedBackGeneratorStyle = feedBackGeneratorStyle
     }
-    
+    #else
+    public init(
+        isPresented: Binding<Bool>,
+        selectedEmoji: Binding<String>,
+        arrowDirection: MCPickerArrowDirection? = nil,
+        customHeight: CGFloat? = nil,
+        horizontalInset: CGFloat? = nil,
+        isDismissAfterChoosing: Bool? = nil,
+        selectedEmojiCategoryTintColor: UIColor? = nil
+    ) {
+        self._isPresented = isPresented
+        self._selectedEmoji = selectedEmoji
+        self.arrowDirection = arrowDirection
+        self.customHeight = customHeight
+        self.horizontalInset = horizontalInset
+        self.isDismissAfterChoosing = isDismissAfterChoosing
+        self.selectedEmojiCategoryTintColor = selectedEmojiCategoryTintColor
+    }
+    #endif
+
     // MARK: - Public Methods
     
     public func makeCoordinator() -> Coordinator {
@@ -119,7 +141,11 @@ public struct MCEmojiPickerRepresentableController: UIViewControllerRepresentabl
             if let selectedEmojiCategoryTintColor {
                 emojiPicker.selectedEmojiCategoryTintColor = selectedEmojiCategoryTintColor
             }
-            if let feedBackGeneratorStyle { emojiPicker.feedBackGeneratorStyle = feedBackGeneratorStyle }
+            #if os(iOS)
+            if let feedBackGeneratorStyle {
+                emojiPicker.feedBackGeneratorStyle = feedBackGeneratorStyle
+            }
+            #endif
             context.coordinator.addPickerDismissingObserver()
             representableController.present(emojiPicker, animated: true)
         case false:

--- a/Sources/MCEmojiPicker/View/MCEmojiPickerViewController.swift
+++ b/Sources/MCEmojiPicker/View/MCEmojiPickerViewController.swift
@@ -72,7 +72,8 @@ public final class MCEmojiPickerViewController: UIViewController {
             popoverPresentationController?.sourceView = sourceView
         }
     }
-    
+
+    #if os(iOS)
     /// Feedback generator style. To turn off, set `nil` to this parameter.
     ///
     /// The default value of this property is `.light`.
@@ -85,10 +86,14 @@ public final class MCEmojiPickerViewController: UIViewController {
             generator = UIImpactFeedbackGenerator(style: feedBackGeneratorStyle)
         }
     }
-    
+    #endif
+
     // MARK: - Private Properties
-    
+
+    #if os(iOS)
     private var generator: UIImpactFeedbackGenerator? = UIImpactFeedbackGenerator(style: .light)
+    #endif
+
     private var viewModel: MCEmojiPickerViewModelProtocol = MCEmojiPickerViewModel()
     private lazy var emojiPickerView: MCEmojiPickerView = {
         let categories = viewModel.emojiCategories.map { $0.type }
@@ -155,7 +160,9 @@ public final class MCEmojiPickerViewController: UIViewController {
     }
     
     private func setupPreferredContentSize() {
+        let defaultSize = CGSize(width: 340, height: 380)
         preferredContentSize = {
+            #if os(iOS)
             switch UIDevice.current.userInterfaceIdiom {
             case .phone:
                 let sideInset: CGFloat = 19
@@ -168,8 +175,11 @@ public final class MCEmojiPickerViewController: UIViewController {
                     height: customHeight ?? popoverWidth * heightProportionToWidth
                 )
             default:
-                return CGSize(width: 340, height: 380)
+                return defaultSize
             }
+            #else
+            return defaultSize
+            #endif
         }()
     }
     
@@ -233,7 +243,9 @@ extension MCEmojiPickerViewController: MCEmojiPickerViewDelegate {
     }
     
     func feedbackImpactOccurred() {
+        #if os(iOS)
         generator?.impactOccurred()
+        #endif
     }
     
     func didChoiceEmoji(_ emoji: MCEmoji?) {

--- a/Sources/MCEmojiPicker/View/Views/EmojiCategoryView/MCEmojiCategoryIconView.swift
+++ b/Sources/MCEmojiPicker/View/Views/EmojiCategoryView/MCEmojiCategoryIconView.swift
@@ -37,7 +37,7 @@ final class MCEmojiCategoryIconView: UIView {
     /// Target icon type.
     private var type: MCEmojiCategoryType
     /// Current tint color for the icon.
-    private var currentIconTintColor: UIColor = .systemGray
+    private var currentIconTintColor: UIColor = .secondaryText
     /// Selected tint color for the icon.
     private var selectedIconTintColor: UIColor
     /// Current icon state.
@@ -69,7 +69,7 @@ final class MCEmojiCategoryIconView: UIView {
         self.state = state
         switch state {
         case .standard:
-            currentIconTintColor = .systemGray
+            currentIconTintColor = .secondaryText
         case .highlighted:
             currentIconTintColor = adjust(color: currentIconTintColor)
         case .selected:

--- a/Sources/MCEmojiPicker/View/Views/EmojiSkinTonePickerView/MCEmojiSkinTonePickerContainerView.swift
+++ b/Sources/MCEmojiPicker/View/Views/EmojiSkinTonePickerView/MCEmojiSkinTonePickerContainerView.swift
@@ -78,11 +78,13 @@ final class MCEmojiSkinTonePickerContainerView: UIView {
     }
     
     deinit {
+        #if !os(visionOS)
         NotificationCenter.default.removeObserver(
             self,
             name: UIDevice.orientationDidChangeNotification,
             object: nil
         )
+        #endif
     }
     
     // MARK: - Actions
@@ -104,12 +106,14 @@ final class MCEmojiSkinTonePickerContainerView: UIView {
     }
     
     private func setupNotifications() {
+        #if !os(visionOS)
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(orientationChanged),
             name: UIDevice.orientationDidChangeNotification,
             object: nil
         )
+        #endif
     }
     
     private func setupGestureRecognizers() {

--- a/Sources/MCEmojiPicker/View/Views/MCEmojiPickerView.swift
+++ b/Sources/MCEmojiPicker/View/Views/MCEmojiPickerView.swift
@@ -88,7 +88,21 @@ final class MCEmojiPickerView: UIView {
         )
         return collectionView
     }()
-    
+
+    #if os(visionOS)
+    private let categoriesStackViewContainer = UIVisualEffectView(effect: UIBlurEffect(style: .systemThinMaterial))
+    #else
+    private let categoriesStackViewContainer = UIView()
+    #endif
+
+    private var categoriesStackViewContentView: UIView {
+        #if os(visionOS)
+        categoriesStackViewContainer.contentView
+        #else
+        categoriesStackViewContainer
+        #endif
+    }
+
     private let categoriesStackView: UIStackView = {
         let stackView = UIStackView()
         stackView.translatesAutoresizingMaskIntoConstraints = false
@@ -173,27 +187,38 @@ final class MCEmojiPickerView: UIView {
         let separatorView = UIView()
         separatorView.translatesAutoresizingMaskIntoConstraints = false
         separatorView.backgroundColor = Constants.separatorColor
-        
-        addSubview(categoriesStackView)
+
+        categoriesStackViewContentView.addSubview(categoriesStackView)
+        categoriesStackViewContainer.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(categoriesStackViewContainer)
         addSubview(separatorView)
-        
+
         NSLayoutConstraint.activate([
-            categoriesStackView.leadingAnchor.constraint(
-                equalTo: leadingAnchor,
-                constant: Constants.categoriesStackViewInsets.left
+            categoriesStackViewContainer.leadingAnchor.constraint(
+                equalTo: leadingAnchor
             ),
-            categoriesStackView.trailingAnchor.constraint(
-                equalTo: trailingAnchor,
-                constant: Constants.categoriesStackViewInsets.right
+            categoriesStackViewContainer.trailingAnchor.constraint(
+                equalTo: trailingAnchor
             ),
-            categoriesStackView.bottomAnchor.constraint(
+            categoriesStackViewContainer.bottomAnchor.constraint(
                 equalTo: bottomAnchor,
                 constant: -safeAreaInsets.bottom
             ),
-            categoriesStackView.heightAnchor.constraint(
+            categoriesStackViewContainer.heightAnchor.constraint(
                 equalToConstant: categoriesStackViewHeight
             ),
-            
+
+            categoriesStackView.leadingAnchor.constraint(
+                equalTo: categoriesStackViewContentView.leadingAnchor,
+                constant: Constants.categoriesStackViewInsets.left
+            ),
+            categoriesStackView.trailingAnchor.constraint(
+                equalTo: categoriesStackViewContentView.trailingAnchor,
+                constant: Constants.categoriesStackViewInsets.right
+            ),
+            categoriesStackView.topAnchor.constraint(equalTo: categoriesStackViewContentView.topAnchor),
+            categoriesStackView.bottomAnchor.constraint(equalTo: categoriesStackViewContentView.bottomAnchor),
+
             separatorView.leadingAnchor.constraint(equalTo: leadingAnchor),
             separatorView.trailingAnchor.constraint(equalTo: trailingAnchor),
             separatorView.topAnchor.constraint(equalTo: categoriesStackView.topAnchor),

--- a/Sources/MCEmojiPicker/View/Views/MCEmojiSectionHeader.swift
+++ b/Sources/MCEmojiPicker/View/Views/MCEmojiSectionHeader.swift
@@ -28,8 +28,7 @@ final class MCEmojiSectionHeader: UICollectionReusableView {
     
     private enum Constants {
         static let backgroundColor = UIColor.popoverBackgroundColor
-        
-        static let headerLabelColor = UIColor.systemGray
+        static let headerLabelColor = UIColor.secondaryText
         static let headerLabelFont = UIFont.systemFont(ofSize: 14.fit(), weight: .regular)
         static let headerLabelInsets = UIEdgeInsets(top: 0, left: 7, bottom: -4, right: -16)
     }


### PR DESCRIPTION
This adds visionOS support with native styling and controls.

- It updates most usage of `.systemGray` with an appropriate adaptive secondary label color
- It conditionally compiles out API endpoints that don't apply to visionOS (because the APIs they use are unavailable)
- It adds a blur background behind the category buttons
- It adopts the UIScene lifecycle in the example app (best practice for visionOS, especially since UIScreen.main is unavailable).

<img width="579" height="650" alt="Screenshot 2025-09-06 at 8 16 17 PM" src="https://github.com/user-attachments/assets/f15c70a5-77f3-4350-ae18-53f3c8b8adab" />

Fixes #19 
